### PR TITLE
Detect react import default and named

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -24,7 +24,7 @@
       }
     },
     "..": {
-      "version": "1.2.2",
+      "version": "2.1.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -67,6 +67,17 @@ describe('createLiveEditStory', () => {
     await screen.findByText('Hello');
   });
 
+  test("allows import React, { named } from 'react'", async () => {
+    const Story = createLiveEditStory({
+      code: `import React, { useState } from 'react';
+             export default () => <div>Hello</div>;`,
+    });
+
+    render(<Story />);
+
+    await screen.findByText('Hello');
+  });
+
   test('adds available imports', async () => {
     const Story = createLiveEditStory({
       availableImports: { a: { b: 'c' } },

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -13,7 +13,7 @@ interface StoryState {
 }
 
 const store = createStore<StoryState>();
-const hasReactRegex = /import +(\* +as +)?React +from +['"]react['"]/;
+const hasReactRegex = /import\s+(\*\s+as\s+)?React[,\s]/;
 
 function LivePreview({ storyId, storyArgs }: { storyId: string; storyArgs?: any }) {
   const [state, setState] = React.useState(store.getValue(storyId));


### PR DESCRIPTION
Fixes #22 

The proper way would be to use the AST rather than regexp. The easy fix is to detect React as an identifier by changing the regexp to /import +(\* +as +)?React[, ]/.