### PR TITLE
Fix iframed storybook sites

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -9011,7 +9011,7 @@
     "node_modules/storybook-addon-code-editor": {
       "version": "0.0.0",
       "resolved": "file:../storybook-addon-code-editor-0.0.0.tgz",
-      "integrity": "sha512-zoab9QTY0JFxI458XTiIynIfKDdM8/c6U2pG9HWCNqctTmo05GSWQRA8YfAbR5uD3CCLwhWHz8iaGRTKhQ8oag==",
+      "integrity": "sha512-QGSIgOJGxB9fWC2FSgCKOqBrCrHzEKYCQHHb0xj5lEtIEBYFx76Byw3WthDC87f5AgwvI2DdXWAHigXN6w6llw==",
       "dev": true,
       "dependencies": {
         "@babel/standalone": "^7.24.5",
@@ -10043,9 +10043,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.17.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.0.tgz",
-      "integrity": "sha512-uJq6108EgZMAl20KagGkzCKfMEjxmKvZHG7Tlq0Z6nOky7YF7aq4mOx6xK8TJ/i1LeK4Qus7INktacctDgY8Ow==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
       "dev": true,
       "engines": {
         "node": ">=10.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8134,9 +8134,10 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.17.0",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },

--- a/scripts/createChildProcess.js
+++ b/scripts/createChildProcess.js
@@ -1,10 +1,10 @@
 // @ts-check
 
-import { spawn } from "node:child_process";
+import { spawn } from 'node:child_process';
 
 // Collect all child processes and kill them when this node process exits.
 const childProcesses = new Set();
-process.on("exit", () => childProcesses.forEach((child) => child.kill()));
+process.on('exit', () => childProcesses.forEach((child) => child.kill()));
 
 export function createChildProcess(command, args, options = {}) {
   let resolve;
@@ -18,30 +18,21 @@ export function createChildProcess(command, args, options = {}) {
 
   childProcesses.add(childP);
 
-  const stdoutData = [];
-
-  childP.stdout?.on("data", (data) => {
-    stdoutData.push(data);
-  });
-
-  childP.once("error", (err) => {
+  childP.once('error', (err) => {
     reject(err);
   });
 
-  childP.once("close", (code) => {
+  childP.once('close', (code) => {
     childProcesses.delete(childP);
     if (code !== 0) {
-      reject(new Error(`Command "${command} ${args.join(" ")}" exited with code ${code}`));
+      reject(new Error(`Command "${command} ${args.join(' ')}" exited with code ${code}`));
       return;
     }
-    resolve({
-      process: childP,
-      stdout: stdoutData.join("").trim(),
-    });
+    resolve();
   });
 
   return {
     childProcess: childP,
     promise,
-  }
+  };
 }

--- a/src/createStore.ts
+++ b/src/createStore.ts
@@ -48,5 +48,12 @@ function newKeyStore<T>(): KeyStore<T> {
 }
 
 export function createStore<T>(): KeyStore<T> {
-  return ((window.top as any)._addon_code_editor_store ||= newKeyStore());
+  try {
+    return ((window.top as any)._addon_code_editor_store ||= newKeyStore());
+  } catch {
+    // Storybook sites can be embedded in iframes. Using window.top will fail in that case.
+    // Try window.parent as a fallback. This can break if Storybook changes how previews are rendered.
+    // TODO: Use Storybook Channels to communicate between the manager and preview.
+    return ((window.parent as any)._addon_code_editor_store ||= newKeyStore());
+  }
 }


### PR DESCRIPTION
Iframed Storybook sites fail due to `window.top` access. This change adds a fallback: `window.parent`.