### PR TITLE
Fix embedded stories

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -9011,7 +9011,7 @@
     "node_modules/storybook-addon-code-editor": {
       "version": "0.0.0",
       "resolved": "file:../storybook-addon-code-editor-0.0.0.tgz",
-      "integrity": "sha512-QGSIgOJGxB9fWC2FSgCKOqBrCrHzEKYCQHHb0xj5lEtIEBYFx76Byw3WthDC87f5AgwvI2DdXWAHigXN6w6llw==",
+      "integrity": "sha512-XUnoUScriQp5hqHBUpUX6nTvFLfo+0CZNiX6D8tG+b5zQKSHWU9dB3cw1IV0E/M9k6QtthFzYf7MdR6V5c6JyQ==",
       "dev": true,
       "dependencies": {
         "@babel/standalone": "^7.24.5",


### PR DESCRIPTION
Fixes #44.

An attempt was made to use Storybook's `addons.getChannel()` but it doesn't seem to emit events across iframes.