### PR TITLE
fix: Node 22.12 error with `dist/cjs` imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "getStaticDirs.d.ts"
   ],
   "scripts": {
-    "build": "node scripts/rm.js dist && tsc --outDir dist/es && babel src --out-dir dist/cjs --extensions '.ts,.tsx' && node scripts/npmPackDev.js",
+    "build": "node scripts/rm.js dist && tsc --outDir dist/es && babel src --out-dir dist/cjs --extensions '.ts,.tsx' && node scripts/npmPackDev.js && node scripts/post-build.js",
     "format": "prettier src example/src --write",
     "start:example": "npm run build && cd example && npm i ../storybook-addon-code-editor-0.0.0.tgz && npm run storybook:dev",
     "build:example": "npm run build && cd example && npm i ../storybook-addon-code-editor-0.0.0.tgz && npm run storybook:build",

--- a/scripts/post-build.js
+++ b/scripts/post-build.js
@@ -1,0 +1,10 @@
+import { writeFileSync } from 'fs';
+import { join } from 'path';
+
+const cjsDir = join(process.cwd(), 'dist', 'cjs');
+
+const packageJsonContent = {
+  type: 'commonjs',
+};
+
+writeFileSync(join(cjsDir, 'package.json'), JSON.stringify(packageJsonContent, null, 2));


### PR DESCRIPTION
Resolves: #53 