### PR TITLE
Add makeLiveEditStory to replace createLiveEditStory

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -3353,7 +3353,7 @@
     "node_modules/storybook-addon-code-editor": {
       "version": "0.0.0",
       "resolved": "file:../storybook-addon-code-editor-0.0.0.tgz",
-      "integrity": "sha512-pVlFK6JNNrzPjGQCxh86DzTy/zsWoca31aNLSgMNA5fmQ5pmyeSjP7SRs3pJBFbHpQOBu/qXHL/4YgmD/ME16A==",
+      "integrity": "sha512-8FJT5ySJ+ZG4yE/MdIbcv2XjgKsS7n5I9ZqmHQKlOT+N2s9jQSkUd3IFTQ572UtZusYVw9sZ7N47uRUk8dR7lw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/example/src/Button/stories/Button.stories.tsx
+++ b/example/src/Button/stories/Button.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { createLiveEditStory } from 'storybook-addon-code-editor';
+import { makeLiveEditStory } from 'storybook-addon-code-editor';
 import * as ExampleLibrary from '../../index';
 import ButtonJsSource from './editableStory.source.js?raw';
 import ButtonTsSource from './editableStory.source.tsx?raw';
@@ -11,16 +11,22 @@ const meta = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
+  tags: ['autodocs', 'typescript'],
 } satisfies Meta<typeof ExampleLibrary.Button>;
 
 export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const EditableStoryJSSource = createLiveEditStory<Story>({
-  availableImports: { 'example-library': ExampleLibrary },
+// Stories declared as normal.
+export const EditableStoryJSSource: Story = {
+  tags: ['!typescript'],
+};
+
+// Modifies the story to add a live code editor panel.
+makeLiveEditStory(EditableStoryJSSource, {
   code: ButtonJsSource,
+  availableImports: { 'example-library': ExampleLibrary },
   modifyEditor(monaco, editor) {
     monaco.languages.typescript.typescriptDefaults.setDiagnosticsOptions({
       noSemanticValidation: true,
@@ -29,7 +35,9 @@ export const EditableStoryJSSource = createLiveEditStory<Story>({
   },
 });
 
-export const EditableStoryTSSource = createLiveEditStory<Story>({
+export const EditableStoryTSSource: Story = {};
+
+makeLiveEditStory(EditableStoryTSSource, {
   availableImports: { 'example-library': ExampleLibrary },
   code: ButtonTsSource,
   modifyEditor(monaco, editor) {
@@ -41,7 +49,14 @@ export const EditableStoryTSSource = createLiveEditStory<Story>({
   },
 });
 
-export const EditableStoryWithControls = createLiveEditStory<Story>({
+export const EditableStoryWithControls: Story = {
+  args: {
+    backgroundColor: 'black',
+    children: 'Set this text in the controls tab',
+  },
+};
+
+makeLiveEditStory(EditableStoryWithControls, {
   availableImports: { 'example-library': ExampleLibrary },
   code: `
     import { Button } from 'example-library';
@@ -58,10 +73,6 @@ export const EditableStoryWithControls = createLiveEditStory<Story>({
     });
     monaco.editor.setTheme('vs-dark');
   },
-  args: {
-    backgroundColor: 'black',
-    children: 'Set this text in the controls tab',
-  },
 });
 
 export const nonEditableStoryArgs: Story = {
@@ -69,4 +80,5 @@ export const nonEditableStoryArgs: Story = {
     backgroundColor: 'lightblue',
     children: 'Use the controls tab to edit me',
   },
+  tags: ['!typescript'],
 };

--- a/example/src/Input/stories/Input.stories.tsx
+++ b/example/src/Input/stories/Input.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { createLiveEditStory } from 'storybook-addon-code-editor';
+import { makeLiveEditStory } from 'storybook-addon-code-editor';
 import * as ExampleLibrary from '../../index';
 import InputTsSource from './editableStory.source.tsx?raw';
 
@@ -12,7 +12,9 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const EditableStory = createLiveEditStory<Story>({
+export const EditableStory: Story = {};
+
+makeLiveEditStory(EditableStory, {
   availableImports: { 'example-library': ExampleLibrary },
   code: InputTsSource,
 });

--- a/example/src/intro.mdx
+++ b/example/src/intro.mdx
@@ -100,36 +100,44 @@ ${code}
 ---
 
 {(() => {
-  const code = 'export default () => <h1>Custom container with editor options (no minimap)</h1>;';
+  const code = 'export default () => <h1>Custom container and editor style</h1>;';
   const Container = (props) => (
-    <div style={{ background: '#b7e1ee' }}>
+    <div style={{ background: '#b7e1ee', borderRadius: '6px', overflow: 'hidden' }}>
       <div style={{ margin: '16px', paddingTop: '16px', overflow: 'auto' }}>
         {props.preview}
       </div>
-      <div style={{ height: '350px', overflow: 'auto', resize: 'vertical' }}>
+      <div style={{ height: '550px', overflow: 'auto', resize: 'vertical' }}>
         {props.editor}
       </div>
     </div>
   );
   return (
     <Playground
-      defaultEditorOptions={{ minimap: { enabled: false } }}
+      defaultEditorOptions={{
+        minimap: { enabled: false },
+        lineNumbers: 'off',
+        fontSize: '15pt',
+      }}
       Container={Container}
       code={`
 /\* MDX:
 import { Playground } from 'storybook-addon-code-editor';
 const Container = (props) => (
-  <div style={{ background: '#b7e1ee' }}>
+  <div style={{ background: '#b7e1ee', borderRadius: '6px', overflow: 'hidden' }}>
     <div style={{ margin: '16px', paddingTop: '16px', overflow: 'auto' }}>
       {props.preview}
     </div>
-    <div style={{ height: '350px', overflow: 'auto', resize: 'vertical' }}>
+    <div style={{ height: '550px', overflow: 'auto', resize: 'vertical' }}>
       {props.editor}
     </div>
   </div>
 );
 <Playground
-  defaultEditorOptions={{minimap: { enabled: false }}}
+  defaultEditorOptions={{
+    minimap: { enabled: false },
+    lineNumbers: 'off',
+    fontSize: '15pt',
+  }}
   Container={Container}
   code="${code}"
 />

--- a/src/Editor/Editor.tsx
+++ b/src/Editor/Editor.tsx
@@ -24,12 +24,13 @@ function loadMonacoEditor() {
         noSyntaxValidation: false,
       });
 
-      if (reactTypes) {
+      reactTypes.forEach(([packageName, dTsFile]) => {
+        const pName = packageName.replace('@types/', '');
         monaco.languages.typescript.typescriptDefaults.addExtraLib(
-          reactTypes,
-          'file:///node_modules/react/index.d.ts',
+          dTsFile,
+          `file:///node_modules/${pName}`,
         );
-      }
+      });
 
       monacoSetup.onMonacoLoad?.(monaco);
 

--- a/src/Editor/reactTypesLoader.ts
+++ b/src/Editor/reactTypesLoader.ts
@@ -1,8 +1,14 @@
 export function reactTypesLoader() {
-  return fetch('@types/react/index.d.ts').then(
-    (resp) => {
-      return resp.text();
-    },
-    () => {},
-  );
+  const typeLibs = ['@types/react/index.d.ts', '@types/react/jsx-runtime.d.ts'];
+
+  return Promise.all(
+    typeLibs.map((typeLib) => {
+      return fetch(typeLib, { headers: { accept: 'text/plain' } }).then(
+        async (resp) => [typeLib, await resp.text()],
+        () => {},
+      );
+    }),
+  ).then((typeLibs) => {
+    return typeLibs.filter((l) => Array.isArray(l));
+  });
 }

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -3,7 +3,18 @@ import * as React from 'react';
 import { afterEach, describe, expect, test } from 'vitest';
 import { createStore } from './createStore';
 import { getCodeEditorStaticDirs, getExtraStaticDir } from './getStaticDirs';
-import { createLiveEditStory, Playground, setupMonaco } from './index';
+import { makeLiveEditStory, Playground, setupMonaco, type StoryState } from './index';
+
+type StorybookStory = {
+  render: (...args: any[]) => React.ReactNode;
+  parameters: {
+    liveCodeEditor: {
+      disable: boolean;
+      id: string;
+    };
+  };
+  [key: string]: unknown;
+};
 
 const originalConsoleError = console.error;
 
@@ -13,104 +24,104 @@ afterEach(() => {
   document.body.innerHTML = '';
 });
 
-describe('createLiveEditStory', () => {
+describe('makeLiveEditStory', () => {
   test('is a function', () => {
-    expect(typeof createLiveEditStory).toBe('function');
+    expect(typeof makeLiveEditStory).toBe('function');
   });
 
   test('renders error', async () => {
-    const Story = createLiveEditStory({ code: '' });
+    const Story = {} as StorybookStory;
+    makeLiveEditStory(Story, { code: '' });
 
-    render(<Story />);
+    render(Story.render());
 
     await screen.findByText('TypeError: Default export is not a React component');
   });
 
   test("renders eval'd code", async () => {
-    const Story = createLiveEditStory({ code: 'export default () => <div>Hello</div>' });
+    const Story = {} as StorybookStory;
+    makeLiveEditStory(Story, { code: 'export default () => <div>Hello</div>' });
 
-    render(<Story />);
+    render(Story.render());
 
     await screen.findByText('Hello');
   });
 
   test('allows import React', async () => {
-    const Story = createLiveEditStory({
+    const Story = {} as StorybookStory;
+    makeLiveEditStory(Story, {
       code: `import React from 'react';
              export default () => <div>Hello</div>;`,
     });
 
-    render(<Story />);
+    render(Story.render());
 
     await screen.findByText('Hello');
   });
 
   test('allows import * as React', async () => {
-    const Story = createLiveEditStory({
+    const Story = {} as StorybookStory;
+    makeLiveEditStory(Story, {
       code: `import * as React from 'react';
              export default () => <div>Hello</div>;`,
     });
 
-    render(<Story />);
+    render(Story.render());
 
     await screen.findByText('Hello');
   });
 
   test("allows import { named } from 'react'", async () => {
-    const Story = createLiveEditStory({
+    const Story = {} as StorybookStory;
+    makeLiveEditStory(Story, {
       code: `import { useState } from 'react';
              export default () => <div>Hello</div>;`,
     });
 
-    render(<Story />);
+    render(Story.render());
 
     await screen.findByText('Hello');
   });
 
   test("allows import React, { named } from 'react'", async () => {
-    const Story = createLiveEditStory({
+    const Story = {} as StorybookStory;
+    makeLiveEditStory(Story, {
       code: `import React, { useState } from 'react';
              export default () => <div>Hello</div>;`,
     });
 
-    render(<Story />);
+    render(Story.render());
 
     await screen.findByText('Hello');
   });
 
   test('adds available imports', async () => {
-    const Story = createLiveEditStory({
+    const Story = {} as StorybookStory;
+    makeLiveEditStory(Story, {
       availableImports: { a: { b: 'c' } },
       code: `import { b } from 'a';
              export default () => <div>{b}</div>;`,
     });
 
-    render(<Story />);
+    render(Story.render());
 
     await screen.findByText('c');
   });
 
   test('passes props to evaluated component', async () => {
-    const Story = createLiveEditStory({ code: 'export default (props) => <div>{props.a}</div>;' });
+    const Story = {} as StorybookStory;
+    makeLiveEditStory(Story, { code: 'export default (props) => <div>{props.a}</div>;' });
 
-    render(<Story a="b" />);
+    render(Story.render({ a: 'b' }));
 
     await screen.findByText('b');
   });
 
-  test('assigns given properties to story', async () => {
-    const Story = createLiveEditStory({
-      code: 'export default (props) => <div>{props.a}</div>;',
-      args: { a: 'b' },
-    });
-
-    expect(Story.args).toEqual({ a: 'b' });
-  });
-
   test('recovers from syntax errors', async () => {
-    const Story = createLiveEditStory({ code: '] this is not valid code [' });
+    const Story = {} as StorybookStory;
+    makeLiveEditStory(Story, { code: '] this is not valid code [' });
 
-    render(<Story />);
+    render(Story.render());
 
     await screen.findByText('SyntaxError', { exact: false });
 
@@ -122,9 +133,10 @@ describe('createLiveEditStory', () => {
   });
 
   test('recovers from runtime errors', async () => {
-    const Story = createLiveEditStory({ code: 'window.thisIsNot.defined' });
+    const Story = {} as StorybookStory;
+    makeLiveEditStory(Story, { code: 'window.thisIsNot.defined' });
 
-    render(<Story />);
+    render(Story.render());
 
     await screen.findByText("TypeError: Cannot read properties of undefined (reading 'defined')");
 
@@ -139,11 +151,12 @@ describe('createLiveEditStory', () => {
     // React's error boundaries use console.error and make this test noisy.
     console.error = () => {};
 
-    const Story = createLiveEditStory({
+    const Story = {} as StorybookStory;
+    makeLiveEditStory(Story, {
       code: 'export default () => <div>{window.thisIsNot.defined}</div>',
     });
 
-    render(<Story />);
+    render(Story.render());
 
     await screen.findByText("TypeError: Cannot read properties of undefined (reading 'defined')");
 

--- a/src/manager.tsx
+++ b/src/manager.tsx
@@ -4,9 +4,7 @@ import * as React from 'react';
 import { addonId, panelId, paramId } from './constants';
 import { createStore } from './createStore';
 import Editor from './Editor/Editor';
-import type { createLiveEditStory } from './index';
-
-type StoryState = Parameters<typeof createLiveEditStory>[0];
+import type { StoryState } from './index';
 
 const store = createStore<StoryState>();
 


### PR DESCRIPTION
Issue #62 caused me to take a deeper look at what Storybook does when generating stories. Storybook expects an object literal as the story definition so it can do build-time things with the object values. Unfortunately, this means `createLiveEditStory` is not a good utility as it stops Storybook from doing build-time things.

This change fixes #62 but also deprecates `createLiveEditStory`. It is still available, but will be removed in the next major version. `makeLiveEditStory` replaces it. `makeLiveEditStory` accepts the same options as `createLiveEditStory` but takes a story object as its first argument. This means you must define your stories exactly as Storybook expects, then call `makeLiveEditStory` to show the code editor addon panel. Example:

```ts
// Before:
export const MyStory = createLiveEditStory<Story>({
  code: mySource,
});

// After:
export const MyStory: Story = {};

makeLiveEditStory(MyStory, {
  code: mySource,
});
```