### PR TITLE
fix: add tags to MinimalStoryObj

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -46,6 +46,7 @@ type AnyFn = (...args: any[]) => unknown;
 // Only define the types from Storybook that are used in makeLiveEditStory.
 // This allows us to support multiple versions of Storybook.
 type MinimalStoryObj = {
+  tags?: string;
   parameters?: {
     liveCodeEditor?: {
       disable: boolean;


### PR DESCRIPTION
Minimal story can have tags but no other props:

```tsx
export const SomeStory = {
  tags: ['new']
}
``` 

The current `MinimalStoryObj` does not allow that as `tags` is not defined.