### PR TITLE
feat: use esm for file path

### DIFF
--- a/src/getStaticDirs.ts
+++ b/src/getStaticDirs.ts
@@ -1,22 +1,7 @@
 import { createRequire } from 'node:module';
 import path from 'node:path';
 
-// Why not use `__filename` or `import.meta.filename`? Because this file gets compiled to both
-// CommonJS and ES module. `import.meta.filename` is a syntax error in CommonJS and `__filename`
-// is not available in ES modules. We can't use `import.meta.url` at all so we need a workaround.
-function getFileNameFromStack() {
-  const isWindows = process.platform === 'win32';
-  const fullPathRegex = isWindows
-    ? /[a-zA-Z]:\\.*\\getStaticDirs\.[cm]?js/
-    : /\/.*\/getStaticDirs\.[cm]?js/;
-  const match = fullPathRegex.exec(new Error().stack || '');
-  if (!match) {
-    throw new Error('Could not get the file path of storybook-addon-code-editor/getStaticDirs');
-  }
-  return match[0];
-}
-
-const filename = typeof __filename === 'string' ? __filename : getFileNameFromStack();
+const filename = import.meta.filename;
 
 function resolve(reqFn: NodeRequire, packageName: string) {
   try {


### PR DESCRIPTION
Recently there's been growing challenges around the path resolution with windows environments and the regex used to capture them:

```
Error: Could not get the file path of storybook-addon-code-editor/getStaticDirs
    at getFileNameFromStack (file:///C:/Users/dev-acc/code/design-pkg/node_modules/.pnpm/storybook-addon-code-editor_344335fba9e0da31fd999963bc23810e/node_modules/storybook-addon-code-editor/dist/getStaticDirs.js:13:15)
    at file:///C:/Users/dev-acc/code/design-pkg/node_modules/.pnpm/storybook-addon-code-editor_344335fba9e0da31fd999963bc23810e/node_modules/storybook-addon-code-editor/dist/getStaticDirs.js:17:64
    at ModuleJob.run (node:internal/modules/esm/module_job:325:25)
    at async ModuleLoader.import (node:internal/modules/esm/loader:606:24)
    at async importModule (file:///C:/Users/dev-acc/code/design-pkg/node_modules/.pnpm/storybook@10.0.7_@testing-l_b7271a68baa22423834f1f2bf5e13e65/node_modules/storybook/dist/_node-chunks/chunk-ODTNT22I.js:1506:11)
    at async loadMainConfig (file:///C:/Users/dev-acc/code/design-pkg/node_modules/.pnpm/storybook@10.0.7_@testing-l_b7271a68baa22423834f1f2bf5e13e65/node_modules/storybook/dist/_node-chunks/chunk-QWKN7XKO.js:12223:17)
    at async buildDevStandalone (file:///C:/Users/dev-acc/code/design-pkg/node_modules/.pnpm/storybook@10.0.7_@testing-l_b7271a68baa22423834f1f2bf5e13e65/node_modules/storybook/dist/core-server/index.js:12142:18)
    at async withTelemetry (file:///C:/Users/dev-acc/code/design-pkg/node_modules/.pnpm/storybook@10.0.7_@testing-l_b7271a68baa22423834f1f2bf5e13e65/node_modules/storybook/dist/_node-chunks/chunk-R5RWAUHB.js:278:12)
    at async dev (file:///C:/Users/dev-acc/code/design-pkg/node_modules/.pnpm/storybook@10.0.7_@testing-l_b7271a68baa22423834f1f2bf5e13e65/node_modules/storybook/dist/bin/core.js:3668:3)
    at async _Command.<anonymous> (file:///C:/Users/dev-acc/code/design-pkg/node_modules/.pnpm/storybook@10.0.7_@testing-l_b7271a68baa22423834f1f2bf5e13e65/node_modules/storybook/dist/bin/core.js:3735:3)
    at loadMainConfig (file:///C:/Users/dev-acc/code/design-pkg/node_modules/.pnpm/storybook@10.0.7_@testing-l_b7271a68baa22423834f1f2bf5e13e65/node_modules/storybook/dist/_node-chunks/chunk-QWKN7XKO.js:12257:11)
    at async buildDevStandalone (file:///C:/Users/dev-acc/code/design-pkg/node_modules/.pnpm/storybook@10.0.7_@testing-l_b7271a68baa22423834f1f2bf5e13e65/node_modules/storybook/dist/core-server/index.js:12142:18)
    at async withTelemetry (file:///C:/Users/dev-acc/code/design-pkg/node_modules/.pnpm/storybook@10.0.7_@testing-l_b7271a68baa22423834f1f2bf5e13e65/node_modules/storybook/dist/_node-chunks/chunk-R5RWAUHB.js:278:12)
    at async dev (file:///C:/Users/dev-acc/code/design-pkg/node_modules/.pnpm/storybook@10.0.7_@testing-l_b7271a68baa22423834f1f2bf5e13e65/node_modules/storybook/dist/bin/core.js:3668:3)
    at async _Command.<anonymous> (file:///C:/Users/dev-acc/code/design-pkg/node_modules/.pnpm/storybook@10.0.7_@testing-l_b7271a68baa22423834f1f2bf5e13e65/node_modules/storybook/dist/bin/core.js:3735:3)

Broken build, fix the error above.
You may need to refresh the browser.

  Failed to load preset: "C:/Users/dev-acc/code/design-pkg/packages/design-pkg-staging/.storybook/main.ts"
Error: Could not get the file path of storybook-addon-code-editor/getStaticDirs
    at getFileNameFromStack (file:///C:/Users/dev-acc/code/design-pkg/node_modules/.pnpm/storybook-addon-code-editor_344335fba9e0da31fd999963bc23810e/node_modules/storybook-addon-code-editor/dist/getStaticDirs.js:13:15)
    at file:///C:/Users/dev-acc/code/design-pkg/node_modules/.pnpm/storybook-addon-code-editor_344335fba9e0da31fd999963bc23810e/node_modules/storybook-addon-code-editor/dist/getStaticDirs.js:17:64
    at ModuleJob.run (node:internal/modules/esm/module_job:325:25)
    at async ModuleLoader.import (node:internal/modules/esm/loader:606:24)
    at async importModule (file:///C:/Users/dev-acc/code/design-pkg/node_modules/.pnpm/storybook@10.0.7_@testing-l_b7271a68baa22423834f1f2bf5e13e65/node_modules/storybook/dist/_node-chunks/chunk-ODTNT22I.js:1506:11)
    at async loadMainConfig (file:///C:/Users/dev-acc/code/design-pkg/node_modules/.pnpm/storybook@10.0.7_@testing-l_b7271a68baa22423834f1f2bf5e13e65/node_modules/storybook/dist/_node-chunks/chunk-QWKN7XKO.js:12223:17)
    at async buildDevStandalone (file:///C:/Users/dev-acc/code/design-pkg/node_modules/.pnpm/storybook@10.0.7_@testing-l_b7271a68baa22423834f1f2bf5e13e65/node_modules/storybook/dist/core-server/index.js:12142:18)
    at async withTelemetry (file:///C:/Users/dev-acc/code/design-pkg/node_modules/.pnpm/storybook@10.0.7_@testing-l_b7271a68baa22423834f1f2bf5e13e65/node_modules/storybook/dist/_node-chunks/chunk-R5RWAUHB.js:278:12)
    at async dev (file:///C:/Users/dev-acc/code/design-pkg/node_modules/.pnpm/storybook@10.0.7_@testing-l_b7271a68baa22423834f1f2bf5e13e65/node_modules/storybook/dist/bin/core.js:3668:3)
    at async _Command.<anonymous> (file:///C:/Users/dev-acc/code/design-pkg/node_modules/.pnpm/storybook@10.0.7_@testing-l_b7271a68baa22423834f1f2bf5e13e65/node_modules/storybook/dist/bin/core.js:3735:3)
node:internal/fs/promises:639
  return new FileHandle(await PromisePrototypeThen(
                        ^

Error: EBUSY: resource busy or locked, open 'C:\Users\dev-acc\code\design-pkg\packages\design-pkg-staging\node_modules\.cache\storybook\default\dev-server\storybook-3f3af1ecebbd1410ab417ec0d27bbfcb5d340e177ae159b59fc8626c2dfd9175'
    at async open (node:internal/fs/promises:639:25)
    at async writeFile (node:internal/fs/promises:1216:14)
    at async FileSystemCache.set (file:///C:/Users/dev-acc/code/design-pkg/node_modules/.pnpm/storybook@10.0.7_@testing-l_b7271a68baa22423834f1f2bf5e13e65/node_modules/storybook/dist/_node-chunks/chunk-QWKN7XKO.js:10899:5)
    at async getSessionId (file:///C:/Users/dev-acc/code/design-pkg/node_modules/.pnpm/storybook@10.0.7_@testing-l_b7271a68baa22423834f1f2bf5e13e65/node_modules/storybook/dist/_node-chunks/chunk-MD57HJIM.js:101:3)
    at async prepareRequest (file:///C:/Users/dev-acc/code/design-pkg/node_modules/.pnpm/storybook@10.0.7_@testing-l_b7271a68baa22423834f1f2bf5e13e65/node_modules/storybook/dist/_node-chunks/chunk-SQJQNNLJ.js:1110:21) {
  errno: -4082,
  code: 'EBUSY',
  syscall: 'open',
  path: 'C:\\Users\\dev-acc\\code\\design-pkg\\packages\\design-pkg-staging\\node_modules\\.cache\\storybook\\default\\dev-server\\storybook-3f3af1ecebbd1410ab417ec0d27bbfcb5d340e177ae159b59fc8626c2dfd9175'
}
```

Since Storybook now only supports ESM since v10, removing the logic required to try navigating the mixed world of cjs vs esm and simply using `import.meta.url` for the path makes it a lot simpler. Changing to use resolves the errors seen above.

Let me know what you think :) 