### PR TITLE
fix: Storybook Composition Failures

### DIFF
--- a/src/manager.tsx
+++ b/src/manager.tsx
@@ -26,6 +26,11 @@ addons.register(addonId, (api) => {
 
       const storyState = store.getValue(storyId)!;
 
+      // Handle case where store doesn't have state for this story (e.g., composed Storybooks)
+      if (!storyState) {
+        return null;
+      }
+
       return (
         <AddonPanel active={true}>
           <Editor


### PR DESCRIPTION
This should resolve the issue regarding Storybook Composition crashing when loading up another storybook that is using Live Code Editor. 

What I really want is for this to somehow support live code in full but I don't have the time to look into the feasibility.
