### PR TITLE
feat: link Playground and makeLiveEditStory through a shared id

### DIFF
--- a/src/Playground.test.tsx
+++ b/src/Playground.test.tsx
@@ -1,0 +1,190 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import * as React from 'react';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { createStore } from './createStore';
+import { makeLiveEditStory, Playground, type StoryState } from './index';
+
+// Monaco can't run in the test environment, so stand in a textarea that calls
+// the same `onInput` callback the real editor uses.
+vi.mock('./Editor/Editor', async () => {
+  const react = await import('react');
+
+  return {
+    default: ({ onInput, value }: { onInput: (value: string) => any; value: string }) =>
+      react.createElement('textarea', {
+        'data-testid': 'editor',
+        onChange: (event: React.ChangeEvent<HTMLTextAreaElement>) => onInput(event.target.value),
+        value,
+      }),
+  };
+});
+
+type StorybookStory = {
+  render: (...args: any[]) => React.ReactNode;
+  parameters: { liveCodeEditor: { disable: boolean; id: string } };
+  [key: string]: unknown;
+};
+
+const store = createStore<StoryState>();
+
+const onlyEditor = ({ editor }: { editor: React.ReactNode }) => <>{editor}</>;
+const onlyPreview = ({ preview }: { preview: React.ReactNode }) => <>{preview}</>;
+
+const setEditorValue = (code: string) =>
+  fireEvent.change(screen.getByTestId('editor'), { target: { value: code } });
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('Playground', () => {
+  test('is a function', () => {
+    expect(typeof Playground).toBe('function');
+  });
+
+  test('renders the code prop when the store has no entry for the id', async () => {
+    render(
+      <Playground
+        code="export default () => <div>from prop</div>"
+        id="no-shared-state"
+        Container={onlyPreview}
+      />,
+    );
+
+    await screen.findByText('from prop');
+  });
+
+  test('renders shared code from a story with the same id', async () => {
+    const Story = {} as StorybookStory;
+    makeLiveEditStory(Story, {
+      code: 'export default () => <div>from story</div>',
+      id: 'shared-code',
+    });
+
+    render(<Playground id="shared-code" Container={onlyPreview} />);
+
+    await screen.findByText('from story');
+  });
+
+  test('shared code takes precedence over the code prop', async () => {
+    const Story = {} as StorybookStory;
+    makeLiveEditStory(Story, {
+      code: 'export default () => <div>from store</div>',
+      id: 'shared-code-wins',
+    });
+
+    render(
+      <Playground
+        code="export default () => <div>from prop</div>"
+        id="shared-code-wins"
+        Container={onlyPreview}
+      />,
+    );
+
+    await screen.findByText('from store');
+  });
+
+  test('falls back to shared availableImports', async () => {
+    const Story = {} as StorybookStory;
+    makeLiveEditStory(Story, {
+      availableImports: { a: { b: 'shared import' } },
+      code: `import { b } from 'a';
+             export default () => <div>{b}</div>;`,
+      id: 'shared-imports',
+    });
+
+    render(<Playground id="shared-imports" Container={onlyPreview} />);
+
+    await screen.findByText('shared import');
+  });
+
+  test('updates when the shared code is changed elsewhere', async () => {
+    const Story = {} as StorybookStory;
+    makeLiveEditStory(Story, {
+      code: 'export default () => <div>before</div>',
+      id: 'external-change',
+    });
+
+    render(<Playground id="external-change" Container={onlyPreview} />);
+
+    await screen.findByText('before');
+
+    // Simulates an edit made in the addon panel.
+    store.setValue('external-change', {
+      ...store.getValue('external-change')!,
+      code: 'export default () => <div>after</div>',
+    });
+
+    await screen.findByText('after');
+  });
+
+  test('editor input updates a story with the same id', async () => {
+    const Story = {} as StorybookStory;
+    makeLiveEditStory(Story, {
+      code: 'export default () => <div>initial</div>',
+      id: 'editor-drives-story',
+    });
+
+    render(
+      <>
+        <Playground id="editor-drives-story" Container={onlyEditor} />
+        {Story.render()}
+      </>,
+    );
+
+    await screen.findByText('initial');
+
+    setEditorValue('export default () => <div>edited</div>');
+
+    await screen.findByText('edited');
+  });
+
+  test('editor input preserves the rest of the shared state', async () => {
+    const Story = {} as StorybookStory;
+    makeLiveEditStory(Story, {
+      availableImports: { a: { b: 'shared import' } },
+      code: `import { b } from 'a';
+             export default () => <div>{b}</div>;`,
+      id: 'preserve-shared-state',
+    });
+
+    render(<Playground id="preserve-shared-state" />);
+
+    await screen.findByText('shared import');
+
+    setEditorValue(`import { b } from 'a';
+                    export default () => <div>{'edited ' + b}</div>;`);
+
+    await screen.findByText('edited shared import');
+
+    expect(store.getValue('preserve-shared-state')?.availableImports).toEqual({
+      a: { b: 'shared import' },
+    });
+  });
+
+  test('editor input without an id stays local', async () => {
+    render(<Playground code="export default () => <div>local</div>" />);
+
+    await screen.findByText('local');
+
+    setEditorValue('export default () => <div>local edit</div>');
+
+    await screen.findByText('local edit');
+  });
+
+  test('playgrounds sharing an id stay in sync', async () => {
+    render(
+      <>
+        <Playground code="export default () => <div>one</div>" id="two-playgrounds" />
+        <Playground id="two-playgrounds" Container={onlyPreview} />
+      </>,
+    );
+
+    // The first playground seeds nothing, so the second starts empty.
+    await screen.findByText('one');
+
+    setEditorValue('export default () => <div>both</div>');
+
+    expect(await screen.findAllByText('both')).toHaveLength(2);
+  });
+});

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { afterEach, describe, expect, test } from 'vitest';
 import { createStore } from './createStore';
 import { getCodeEditorStaticDirs, getExtraStaticDir } from './getStaticDirs';
-import { makeLiveEditStory, Playground, setupMonaco, type StoryState } from './index';
+import { makeLiveEditStory, setupMonaco, type StoryState } from './index';
 
 type StorybookStory = {
   render: (...args: any[]) => React.ReactNode;
@@ -27,6 +27,23 @@ afterEach(() => {
 describe('makeLiveEditStory', () => {
   test('is a function', () => {
     expect(typeof makeLiveEditStory).toBe('function');
+  });
+
+  test('generates an id when none is provided', () => {
+    const Story = {} as StorybookStory;
+    makeLiveEditStory(Story, { code: '' });
+
+    expect(Story.parameters.liveCodeEditor.id).toMatch(/^id_/);
+  });
+
+  test('uses the provided id as the store key', () => {
+    const Story = {} as StorybookStory;
+    makeLiveEditStory(Story, { code: 'export default () => null', id: 'my-shared-id' });
+
+    expect(Story.parameters.liveCodeEditor.id).toBe('my-shared-id');
+    expect(createStore<StoryState>().getValue('my-shared-id')?.code).toBe(
+      'export default () => null',
+    );
   });
 
   test('renders error', async () => {
@@ -204,12 +221,6 @@ describe('makeLiveEditStory', () => {
     });
 
     await screen.findByText('Hello');
-  });
-});
-
-describe('Playground', () => {
-  test('is a function', () => {
-    expect(typeof Playground).toBe('function');
   });
 });
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -12,6 +12,15 @@ export interface StoryState {
   defaultEditorOptions?: EditorOptions | undefined;
 }
 
+export interface LiveEditStoryOptions extends StoryState {
+  /**
+   * Stable key for this story's shared code state. Pass the same `id` to
+   * `Playground` to drive the story from an editor rendered elsewhere, such as
+   * an MDX page. Defaults to a generated id.
+   */
+  id?: string | undefined;
+}
+
 const store = createStore<StoryState>();
 const hasReactRegex = /import\s+(\*\s+as\s+)?React[,\s]/;
 const noop = () => {};
@@ -76,10 +85,14 @@ type MinimalStory = MinimalStoryObj | (AnyFn & MinimalStoryObj);
  */
 export function makeLiveEditStory<T extends MinimalStory>(
   story: T,
-  { code, availableImports, modifyEditor, defaultEditorOptions }: StoryState,
+  {
+    code,
+    availableImports,
+    modifyEditor,
+    defaultEditorOptions,
+    id = `id_${Math.random()}`,
+  }: LiveEditStoryOptions,
 ): void {
-  const id = `id_${Math.random()}`;
-
   store.setValue(id, { code, availableImports, modifyEditor, defaultEditorOptions });
 
   story.parameters = {
@@ -97,18 +110,17 @@ export function makeLiveEditStory<T extends MinimalStory>(
   story.render = (props: any) => <LivePreview storyId={id} storyArgs={props} />;
 }
 
-const savedCode: Record<PropertyKey, string> = {};
-
 /**
  * React component containing a live code editor and preview.
  */
 export function Playground({
   availableImports,
   code,
+  defaultEditorOptions,
   height = '200px',
   id,
+  modifyEditor,
   Container,
-  ...editorProps
 }: Partial<StoryState> & {
   height?: string | undefined;
   id?: string | undefined;
@@ -116,26 +128,43 @@ export function Playground({
     | React.ComponentType<{ editor: React.ReactNode; preview: React.ReactNode }>
     | undefined;
 }) {
-  let initialCode = code ?? '';
-  if (id !== undefined) {
-    savedCode[id] ??= initialCode;
-    initialCode = savedCode[id];
-  }
-  const [currentCode, setCurrentCode] = React.useState(initialCode);
+  // When `id` is set, the shared store owns the code. This keeps the editor in
+  // sync with every other consumer of the same id: the addon panel, other
+  // `Playground`s, and stories created by `makeLiveEditStory`.
+  const sharedState = id === undefined ? undefined : store.getValue(id);
+  const [currentCode, setCurrentCode] = React.useState(sharedState?.code ?? code ?? '');
   const errorBoundaryResetRef = React.useRef(noop);
   const fullCode = hasReactRegex.test(currentCode)
     ? currentCode
     : "import * as React from 'react';" + currentCode;
 
+  React.useEffect(() => {
+    if (id === undefined) {
+      return;
+    }
+    return store.onChange(id, (newState) => {
+      setCurrentCode(newState.code);
+      errorBoundaryResetRef.current();
+    });
+  }, [id]);
+
   const editor = (
     <Editor
-      {...editorProps}
+      defaultEditorOptions={defaultEditorOptions ?? sharedState?.defaultEditorOptions}
+      modifyEditor={modifyEditor ?? sharedState?.modifyEditor}
       onInput={(newCode) => {
-        if (id !== undefined) {
-          savedCode[id] = newCode;
-        }
         setCurrentCode(newCode);
         errorBoundaryResetRef.current();
+
+        if (id !== undefined) {
+          const latestState = store.getValue(id);
+          store.setValue(
+            id,
+            latestState
+              ? { ...latestState, code: newCode }
+              : { availableImports, code: newCode, defaultEditorOptions, modifyEditor },
+          );
+        }
       }}
       value={currentCode}
     />
@@ -143,7 +172,10 @@ export function Playground({
 
   const preview = (
     <ErrorBoundary resetRef={errorBoundaryResetRef}>
-      <Preview availableImports={{ react: React, ...availableImports }} code={fullCode} />
+      <Preview
+        availableImports={{ react: React, ...(availableImports ?? sharedState?.availableImports) }}
+        code={fullCode}
+      />
     </ErrorBoundary>
   );
 


### PR DESCRIPTION
Refs #95

## Problem

`Playground` renders its preview itself, outside Storybook's story-rendering pipeline, so no decorators apply to it.

## What this changes

Makes the store key something the user chooses, so the two halves can be linked by name.

- `makeLiveEditStory` accepts an optional `id`, used as the store key instead of a generated one. Falls back to the previous generated id when omitted.
- `Playground`'s existing `id` prop now keys that same store.

Passing the same id to both wires them together:

```tsx
// Button.stories.tsx
export const Editable: Story = {};

makeLiveEditStory(Editable, {
  id: 'button-demo',
  code: buttonSource,
  availableImports: { 'my-library': MyLibrary },
});
```

```mdx
{/* Button.mdx */}
<Playground id="button-demo" Container={({ editor }) => editor} />

<Story of={ButtonStories.Editable} />
```